### PR TITLE
Added afterStateEntered callback to the state class. 

### DIFF
--- a/src/main/java/com/coalminesoftware/jstately/graph/state/DefaultState.java
+++ b/src/main/java/com/coalminesoftware/jstately/graph/state/DefaultState.java
@@ -17,8 +17,13 @@ public class DefaultState<TransitionInput> implements State<TransitionInput> {
 		this.description = description;
 	}
 
+	@Override
 	public void onEnter() { }
 
+	@Override
+	public void afterStateEntered() { }
+
+	@Override
 	public void onExit() { }
 
 	@Override

--- a/src/main/java/com/coalminesoftware/jstately/graph/state/State.java
+++ b/src/main/java/com/coalminesoftware/jstately/graph/state/State.java
@@ -13,6 +13,9 @@ public interface State<TransitionInput> {
 	/** Called by a state machine when the machine enters the state. */
 	void onEnter();
 
+	/** Called by a state machine after the machine has entered the state */
+	void afterStateEntered();
+
 	/** Called by a state machine when the machine exits the state. */
 	void onExit();
 }

--- a/src/main/java/com/coalminesoftware/jstately/machine/StateMachine.java
+++ b/src/main/java/com/coalminesoftware/jstately/machine/StateMachine.java
@@ -180,6 +180,7 @@ public class StateMachine<MachineInput,TransitionInput> {
 
 			newState.onEnter();
 			currentState = newState;
+			newState.afterStateEntered();
 
 			for(StateMachineEventListener<TransitionInput> listener : eventListeners) {
 				listener.afterStateEntered(newState, this);


### PR DESCRIPTION
Hey Brandon! 

We wanted to get your opinion and perhaps propose adding a callback to the state class. 

An issue we were running into when using the state machine was getting an `IllegalStateException` when doing multiple transitions at once. I think we understand the basis for the exception, ideally we wouldn't want to transition to a new state when a transition is already taking place and has not yet been completed. 

The problem with this is that in our app as part of entering a new state we want to run some logic that can potentially lead to a state transition, which in turn gives us that `IllegalStateException`. 

We have gotten around the problem by adding an EventListener to the state graph that checks for the target state & runs that logic in the `afterStateEntered` callback. This works but we think it may be a better fix if we add an `afterStateEntered` callback in the state class instead so we can define behavior for each state separately.

We're curious what your thoughts are on this.